### PR TITLE
Player-specific InfoUtil logging

### DIFF
--- a/core/src/com/week1/game/InfoUtil.java
+++ b/core/src/com/week1/game/InfoUtil.java
@@ -14,8 +14,10 @@ public class InfoUtil {
     private Array<DisplayMessage> toDelete = new Array<>();
     private Matrix4 projectionMatrix = new Matrix4();
     private BitmapFont font = new BitmapFont();
+    int playerID;
 
-    public InfoUtil(boolean messagesOnScreen) {
+    public InfoUtil(int playerID, boolean messagesOnScreen) {
+        this.playerID = playerID;
         this.messagesOnScreen = messagesOnScreen;
     }
 
@@ -23,6 +25,13 @@ public class InfoUtil {
         Gdx.app.log(tag, message);
         if (messagesOnScreen) {
             messages.add(new DisplayMessage(message));
+        }
+    }
+
+    /* Log the message for the given player only. */
+    public void log(int playerID, String tag, String message) {
+        if (this.playerID == playerID) {
+            log(tag, message);
         }
     }
 
@@ -52,7 +61,7 @@ public class InfoUtil {
 
 class DisplayMessage {
     final String text;
-    private int time = 30; // TODO maybe use the delta time to decrement
+    private int time = 40; // TODO maybe use the delta time to decrement
     void decay() {
         time--;
     }

--- a/core/src/com/week1/game/MenuScreens/GameScreen.java
+++ b/core/src/com/week1/game/MenuScreens/GameScreen.java
@@ -47,9 +47,10 @@ public class GameScreen implements Screen {
 	public GameScreen(Client givenNetworkClient) {
 		Initializer.init();
 		gameStage = new Stage(new FitViewport(GameController.VIRTUAL_WIDTH, GameController.VIRTUAL_HEIGHT));
-		util = new InfoUtil(true);
 		// Finish setting up the client.
 		this.networkClient = givenNetworkClient;
+
+		util = new InfoUtil(networkClient.getPlayerId(), true);
 
 		setColorMapping(givenNetworkClient.getInfoList());
 

--- a/core/src/com/week1/game/Networking/Messages/Game/CreateMinionMessage.java
+++ b/core/src/com/week1/game/Networking/Messages/Game/CreateMinionMessage.java
@@ -30,35 +30,32 @@ public class CreateMinionMessage extends GameMessage {
         // TODO do lookup of the cost based on unitType, do not use hardcoded number [tempMinion1Cost/tempMinion1Health]
         if (tempMinion1Cost > inputState.getPlayer(playerID).getMana()) {
             // Do not have enough mana!
-            util.log("pjb3 - CreateMinionMessage", "Not enough mana (" +
+            util.log(playerID, "pjb3 - CreateMinionMessage", "Not enough mana (" +
                     inputState.getPlayer(playerID).getMana() + ") to create unit of cost " + tempMinion1Cost);
             return false; // indicate it was NOT placed
         }
 
         // Test to see if it is in the proximity of a tower or a home base
         if (!inputState.findNearbyStructure(x, y, z, playerID)) {
-            util.log("pjb3 - CreateMinionMessage", "Not close enough to an existing tower or home base");
+            util.log(playerID, "pjb3 - CreateMinionMessage", "Not close enough to an existing tower or home base");
              return false;
         }
         
         if (!inputState.getWorld().getBlock((int)x, (int)y, (int)z - 1).allowMinionToSpawnOn()) {
-            util.log("lji1 - CreateMinionMessage", "Not allowed to spawn minion on tower.");
+            util.log(playerID, "lji1 - CreateMinionMessage", "Not allowed to spawn minion on tower.");
             return false;
         }
         
         if (!(inputState.getWorld().getBlock((int)x, (int)y, (int)z) == Block.TerrainBlock.AIR)) {
-            util.log("lji1 - CreateMinionMessage", "Not allowed to spawn minion in another block");
+            util.log(playerID, "lji1 - CreateMinionMessage", "Not allowed to spawn minion in another block");
             return false;
         }
 
 
         inputState.getPlayer(playerID).useMana(tempMinion1Cost);
 
-        util.log("pjb3 - CreateMinionMessage", "Used " + tempMinion1Cost + " mana to create minion.");
+        util.log(playerID, "pjb3 - CreateMinionMessage", "Used " + tempMinion1Cost + " mana to create minion.");
         inputState.addUnit(x, y, z, (float) tempMinion1Health, playerID);
-//        Gdx.app.postRunnable(() -> {
-//
-//        });
         return true;
     }
 

--- a/core/src/com/week1/game/Networking/Messages/Game/CreateTowerMessage.java
+++ b/core/src/com/week1/game/Networking/Messages/Game/CreateTowerMessage.java
@@ -38,7 +38,7 @@ public class CreateTowerMessage extends GameMessage {
         // Does the player have enough mana
         if (towerCost > inputState.getPlayer(playerID).getMana()) {
             // Do not have enough mana!
-            util.log("pjb3 - CreateTowerMessage", "Not enough mana to create tower. Need " + towerCost);
+            util.log(playerID, "pjb3 - CreateTowerMessage", "Not enough mana to create tower. Need " + towerCost);
             return false; // indicate it was NOT placed
         }
 
@@ -52,12 +52,12 @@ public class CreateTowerMessage extends GameMessage {
 
         // The tower can't be too far from an existing friendly structure
         if (!inputState.findNearbyStructure(x, y, z, playerID)) {
-            util.log("pjb3 - CreateTowerMessage", "Not close enough to an existing tower or home base");
+            util.log(playerID, "pjb3 - CreateTowerMessage", "Not close enough to an existing tower or home base");
             return false;
         }
 
         // Deduct the mana cost from the creating player
-        util.log("pjb3 - CreateTowerMessage", "Used " + towerCost + " mana to create tower.");
+        util.log(playerID, "pjb3 - CreateTowerMessage", "Used " + towerCost + " mana to create tower.");
         inputState.getPlayer(playerID).useMana(towerCost);
 
         // Only create the tower once we're sure it's safe to do so
@@ -97,16 +97,16 @@ public class CreateTowerMessage extends GameMessage {
             if (!((0 <= tempX && tempX < maxX) &&
                     (0 <= tempY && tempY < maxY) &&
                     (0 <= tempZ && tempZ < maxZ))) {
-                util.log("lji1 - CreateTowerMessage", "Can't build tower off the map.");
+                util.log(playerID, "lji1 - CreateTowerMessage", "Can't build tower off the map.");
                 return false;
             }
             if (inputState.getWorld().getBlock(tempX, tempY, tempZ) != Block.TerrainBlock.AIR) {
-                util.log("lji1 - CreateTowerMessage", "Can't build a tower overlapping with existing blocks");
+                util.log(playerID, "lji1 - CreateTowerMessage", "Can't build a tower overlapping with existing blocks");
                 return false;
             }
 
             if (bs.getY() == 0 && !(inputState.getWorld().getBlock(tempX, tempY, tempZ - 1).canSupportTower())) {
-                util.log("lji1 - CreateTowerMessage", "Tower not fully supported by terrain");
+                util.log(playerID, "lji1 - CreateTowerMessage", "Tower not fully supported by terrain");
                 return false;
             }
 
@@ -114,7 +114,7 @@ public class CreateTowerMessage extends GameMessage {
                 Unit minion = minions.get(u);
                 if ((((int)minion.getX() == tempX) || ((int)minion.getX() + 1 == tempX)) &&
                         (((int)minion.getY() == tempY) || ((int)minion.getY() + 1 == tempY))) {
-                    util.log("lji1 - CreateTowerMessage", "Tower overlaps with minion.");
+                    util.log(playerID, "lji1 - CreateTowerMessage", "Tower overlaps with minion.");
                     return false;
                 }
             }


### PR DESCRIPTION
- Extra `log` method on InfoUtil now takes a player ID
- Logging errors (e.g. unable to spawn at given location) only to relevant player now
- Slightly increase message lifetime