### PR TITLE
Click to target

### DIFF
--- a/core/src/com/week1/game/Model/ClickOracle.java
+++ b/core/src/com/week1/game/Model/ClickOracle.java
@@ -301,6 +301,7 @@ public class ClickOracle extends InputAdapter implements Publisher<SelectionEven
         @Override
         public Void acceptUnit(Unit unit) {
             if (unit.getPlayerId() != adapter.getPlayerId()) {
+                moveMultiselected((int) unit.getX(), (int) unit.getY());
                 targetMultiselected(unit.ID);
             }
             return null;
@@ -316,12 +317,14 @@ public class ClickOracle extends InputAdapter implements Publisher<SelectionEven
         @Override
         public Void acceptCrystal(Crystal crystal) {
             // TODO attack this crystal
+            moveMultiselected((int) crystal.getX(), (int) crystal.getY());
             targetMultiselected(crystal.ID);
             return null;
         }
 
         @Override
         public Void acceptTower(Tower t) {
+            moveMultiselected((int) t.getX(), (int) t.getY());
             if (t.getPlayerId() != adapter.getPlayerId()) {
                 targetMultiselected(t.ID);
             }

--- a/core/src/com/week1/game/Model/Components/TargetingComponent.java
+++ b/core/src/com/week1/game/Model/Components/TargetingComponent.java
@@ -9,6 +9,7 @@ import java.util.function.Consumer;
 public class TargetingComponent extends AComponent {
     public int permission;
     public int targetID; // -1 if no current target.
+    public int intentID = -1; // ID that the entity intends to target when possible. -1 if none.
     public float range; // Targeting range.
     public boolean switchTargets; // Whether or not to switch targets when out of range.
     public TargetingStrategy strategy;

--- a/core/src/com/week1/game/Model/GameState.java
+++ b/core/src/com/week1/game/Model/GameState.java
@@ -703,7 +703,10 @@ public class GameState implements GameRenderable {
 
         return null;
     }
+
     public void moveMinion(float x, float y, Unit u) {
+        // If the minion is already there, do nothing.
+        if (u.getX() == x && u.getY() == y) return;
         updateGoal(u, new Vector3(x, y, 0));
     }
 

--- a/core/src/com/week1/game/Networking/Messages/Game/TargetMessage.java
+++ b/core/src/com/week1/game/Networking/Messages/Game/TargetMessage.java
@@ -1,0 +1,32 @@
+package com.week1.game.Networking.Messages.Game;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.utils.Array;
+import com.week1.game.InfoUtil;
+import com.week1.game.Model.Entities.Unit;
+import com.week1.game.Model.GameEngine;
+import com.week1.game.Model.GameState;
+import com.week1.game.Networking.Messages.MessageType;
+
+public class TargetMessage extends GameMessage {
+    private final static MessageType MESSAGE_TYPE = MessageType.TARGET;
+
+    public Array<Integer> minionIDs = new Array<>();
+    public int targetID;
+
+    public TargetMessage(Array<Unit> minions, int targetID, int playerID, int intHash) {
+        super(playerID, MESSAGE_TYPE, intHash);
+        this.targetID = targetID;
+        for (int i = 0; i < minions.size; i++) {
+            minionIDs.add(minions.get(i).ID);
+        }
+    }
+
+    @Override
+    public boolean process(GameEngine engine, GameState gameState, InfoUtil util) {
+        Gdx.app.log("TargetMessage", "Processing TargetMessage");
+        // To make things simple, we'll just pass the game state this entire message.
+        gameState.changeTarget(this);
+        return true;
+    }
+}

--- a/core/src/com/week1/game/Networking/Messages/MessageFormatter.java
+++ b/core/src/com/week1/game/Networking/Messages/MessageFormatter.java
@@ -53,6 +53,8 @@ public class MessageFormatter {
             return g.fromJson(msg, CheckSyncMessage.class);
         } else if (prototypeMessage.messageTypeID == MessageType.TOWERDETAILS){
             return g.fromJson(msg, TowerDetailsMessage.class);
+        } else if (prototypeMessage.messageTypeID == MessageType.TARGET){
+            return g.fromJson(msg, TargetMessage.class);
         }
         Gdx.app.debug(TAG, "Failed to parse as game message.");
         return null;

--- a/core/src/com/week1/game/Networking/Messages/MessageType.java
+++ b/core/src/com/week1/game/Networking/Messages/MessageType.java
@@ -10,6 +10,7 @@ public enum MessageType {
     CHECKSYNC,
     SYNCERR,
     TOWERDETAILS,
+    TARGET,
     
     // Client Control Messages
     PLAYERID,


### PR DESCRIPTION
- Restructured visitors to be a little more clear what action is supposed to be executed, when.
- Right clicking a targetable entity with units selected will generate and send a `TargetMessage`, which is given to the `TargetingSystem` (different from how most messages are handled) to be processed synchronously during the game loop.
# Targeting Behavior
- After selecting a unit, right click on a non-ally entity to target it.
- This will change the unit's "intent". It will attack that entity whenever possible (if that entity isn't in range, it'll just attack the closest as usual).

Testing this has revealed a bug where towers that are placed in fog of war are not marked as "visible" for the owner, even when they've completed spawning.