### PR TITLE
fixed tower visibility

### DIFF
--- a/core/src/com/week1/game/Model/Entities/Tower.java
+++ b/core/src/com/week1/game/Model/Entities/Tower.java
@@ -211,4 +211,7 @@ public class Tower implements Clickable {
     public DamagingComponent getDamagingComponent() {
         return damagingComponent;
     }
+    public void setVisibleComponent(VisibleComponent visibleComponent) {
+        this.visibleComponent = visibleComponent;
+    }
 }

--- a/core/src/com/week1/game/Model/GameState.java
+++ b/core/src/com/week1/game/Model/GameState.java
@@ -569,6 +569,8 @@ public class GameState implements GameRenderable {
         DamagingComponent damagingComponent = tower.getDamagingComponent();
         ManaRewardComponent manaRewardComponent = new ManaRewardComponent(100, 0);
         VisibleComponent visibleComponent = new VisibleComponent(localPlayerID == tower.getPlayerId());
+        // Must update the tower object's visible component, otherwise calls to visible() will be wrong.
+        tower.setVisibleComponent(visibleComponent);
         targetingSystem.addNode(tower.ID, ownedComponent, targetingComponent, positionComponent);
         damageSystem.addHealth(tower.ID, healthComponent);
         damageSystem.addDamage(tower.ID, damagingComponent);


### PR DESCRIPTION
- Had an issue where towers spawned in fog of war weren't being
  visioned properly after the "officially" spawning (i.e. the clickable
  was registering as invisible)
- To fix this, set the visible component of the tower so that it's
  the same component that was added to the system in `addFinishedTower`.

# Testing
To test this change, create a game with fog of war on seed 0.
Spawn a tower in fog of war.
Previously, the entire tower would not highlight (just the block) on
hover. Now it should do so.