### PR TITLE
Stop player input after loss/gameover

### DIFF
--- a/core/src/com/week1/game/MenuScreens/GameScreen.java
+++ b/core/src/com/week1/game/MenuScreens/GameScreen.java
@@ -66,6 +66,7 @@ public class GameScreen implements Screen {
 			@Override
 			public void endGame(int winOrLoss) {
 				renderer.endGame(winOrLoss);
+				clickOracle.stopInput();
 			}
 
 			@Override

--- a/core/src/com/week1/game/Model/ClickOracle.java
+++ b/core/src/com/week1/game/Model/ClickOracle.java
@@ -156,11 +156,6 @@ public class ClickOracle extends InputAdapter implements Publisher<SelectionEven
 
     /* Command to execute when the player drags with left mouse.*/
     private ClickOracleCommand leftDragCommand = () -> {
-        // The player must be alive to be able to register any clicks
-        if (!adapter.isPlayerAlive()) {
-            Gdx.app.debug("pjb3 - ClickOracle", "Player has already died. ignoring touchDragged");
-            return;
-        }
         dragging = true;
         passiveSelected.setHovered(false);
         selectionLocationEnd.set(curX, Gdx.graphics.getHeight() - curY, 0);

--- a/core/src/com/week1/game/Model/Entities/Clickable.java
+++ b/core/src/com/week1/game/Model/Entities/Clickable.java
@@ -42,6 +42,33 @@ public interface Clickable {
     T acceptCrystal(Crystal crystal);
     T acceptTower(Tower t);
     T acceptNull();
+    // A Visitor that does nothing.
+    ClickableVisitor<Void> EMPTY = new ClickableVisitor() {
+        @Override
+        public Void acceptUnit(Unit unit) {
+            return null;
+        }
+
+        @Override
+        public Void acceptBlock(ClickableBlock block) {
+            return null;
+        }
+
+        @Override
+        public Void acceptCrystal(Crystal crystal) {
+            return null;
+        }
+
+        @Override
+        public Void acceptTower(Tower t) {
+            return null;
+        }
+
+        @Override
+        public Void acceptNull() {
+            return null;
+        }
+    };
   }
 
   class ClickableBlock implements Clickable {


### PR DESCRIPTION
- limit interactions with map by changing the commands that execute on touchdown